### PR TITLE
fix(footer): correct hover glow for Hope Art Org

### DIFF
--- a/src/components/footer/index.astro
+++ b/src/components/footer/index.astro
@@ -104,10 +104,12 @@ const locales = Object.keys(languages).map(code => ({
         href="https://github.com/HopeArtOrg"
         target="_blank"
         rel="noopener noreferrer"
-        class=":uno: flex gap-1 w-fit items-center group"
+        class="flex gap-1 w-fit items-center group"
       >
-        <StarIcon class=":uno: text-muted-foreground size-8 transition-colors duration-300 group-hover:text-foreground" />
-        <span class=":uno: text-sm text-muted-foreground font-medium font-mono transition-colors duration-300 group-hover:text-primary">Hope Art Org</span>
+        <StarIcon class="text-muted-foreground size-8 transition-all duration-500 group-hover:text-primary group-hover:drop-shadow-[0_0_10px_oklch(0.55_0.04_255/0.6)]" />
+        <span class="text-sm text-muted-foreground font-medium font-mono inline-block transition-all duration-500 group-hover:text-primary group-hover:drop-shadow-[0_0_10px_oklch(0.55_0.04_255/0.6)]">
+          Hope Art Org
+        </span>
       </a>
       <hr class=":uno: border-0 bg-border h-px w-28" />
       <LanguageSwitch


### PR DESCRIPTION
Bypassed transformerCompileClass by using standard class attributes. Used literal oklch values from the navbar.
