### PR TITLE
fix(footer): ensure cta banner has solid background on blog pages

### DIFF
--- a/src/components/footer/banner/index.astro
+++ b/src/components/footer/banner/index.astro
@@ -6,7 +6,7 @@ const lang = getLangFromUrl(Astro.url);
 const t = useTranslations(lang);
 ---
 
-<div class=":uno: py-5 border-t border-border/15 bg-background/50 w-full sm:py-4">
+<div class=":uno: py-5 border-t border-border/15 bg-background w-full relative z-10 sm:py-4">
   <div class=":uno: mx-auto px-5 flex flex-col gap-3 max-w-screen-xl items-center justify-between sm:px-6 sm:flex-row sm:gap-2">
     <p class=":uno: text-[9px] text-muted-foreground/50 leading-relaxed tracking-[0.15em] text-center uppercase sm:text-[10px] sm:tracking-[0.25em] sm:text-left">
       {t("footer.bannerText")}


### PR DESCRIPTION
Changed bg-background/50 to bg-background and added relative z-10 to match the footer and prevent background animations from bleeding through.
