### PR TITLE
docs(blog): shorten understanding-blind-watermark title

### DIFF
--- a/src/contents/en/understanding-blind-watermark.mdx
+++ b/src/contents/en/understanding-blind-watermark.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Invisible Signatures: Frequency-Domain Watermarking in Hope"
+title: "Invisible Signatures: Blind Watermarking"
 description: "A rigorous exploration of DWT, DCT, and SVD blind watermarking algorithms, and how Hope secures ownership data directly within the image spectrum."
 publishDate: 2026-07-11
 ---
 
-# Invisible Signatures: Frequency-Domain Watermarking in Hope
+# Invisible Signatures: Blind Watermarking
 
 While adversarial cloaking tools like Glaze and Nightshade defend against style hijacking by shifting features in the latent space, creators also require a mechanism to prove ownership of their work after it has been distributed. Conventional watermarks—such as visible stamps or simple metadata headers—are easily removed via cropping, compression, or screenshotting.
 

--- a/src/contents/vn/understanding-blind-watermark.mdx
+++ b/src/contents/vn/understanding-blind-watermark.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Chữ Kí Ẩn: Thuật Toán Nhúng Chữ Kí Miền Tần Số Trong Hope"
+title: "Chữ Kí Ẩn: Nhúng Chữ Kí Miền Tần Số"
 description: "Phân tích chi tiết về thuật toán chữ kí ẩn DWT, DCT và SVD, cùng cách Hope nhúng thông tin sở hữu trực tiếp vào phổ tần số của tác phẩm."
 publishDate: 2026-07-11
 ---
 
-# Chữ Kí Ẩn: Thuật Toán Nhúng Chữ Kí Miền Tần Số Trong Hope
+# Chữ Kí Ẩn: Nhúng Chữ Kí Miền Tần Số
 
 Trong khi các công cụ làm nhiễu đối kháng như Glaze và Nightshade bảo vệ phong cách nghệ thuật bằng cách thay đổi đặc trưng trên không gian tiềm ẩn (latent space), nghệ sĩ vẫn cần một cơ chế để chứng minh quyền sở hữu tác phẩm sau khi công bố. Các loại watermark truyền thống—như dấu logo đóng đè hoặc siêu dữ liệu (metadata)—rất dễ bị loại bỏ khi cắt xén (cropping), nén ảnh, hoặc chụp lại màn hình.
 


### PR DESCRIPTION
Shorten both Vietnamese and English titles of the understanding-blind-watermark blog post to prevent title overflow on the generated OG image.
