### PR TITLE
fix(blog): adjust og image layout and add code examples

### DIFF
--- a/src/components/templates/og/default-og.tsx
+++ b/src/components/templates/og/default-og.tsx
@@ -128,6 +128,13 @@ function GridBackground() {
 }
 
 function DefaultOG({ title, description, version }: DefaultOGProps) {
+  const isLongTitle = title.length > 50;
+  const isMediumTitle = title.length > 30 && title.length <= 50;
+  const titleFontSize = isLongTitle ? "36px" : isMediumTitle ? "48px" : "64px";
+  const titleMarginBottom = isLongTitle ? "16px" : "24px";
+  const descFontSize = isLongTitle ? "18px" : "22px";
+  const separatorMarginBottom = isLongTitle ? "16px" : "24px";
+
   return (
     <div
       tw="w-full h-full flex relative overflow-hidden"
@@ -151,7 +158,7 @@ function DefaultOG({ title, description, version }: DefaultOGProps) {
         <CornerFrame position="br" version={version} />
       </div>
 
-      <div tw="flex w-full h-full px-24 py-20 relative z-10">
+      <div tw="flex w-full h-full px-24 py-16 relative z-10">
         <div tw="flex items-center justify-center w-[45%]">
           <StarLogo />
         </div>
@@ -168,27 +175,35 @@ function DefaultOG({ title, description, version }: DefaultOGProps) {
           </div>
 
           <div
-            tw="text-7xl font-bold tracking-tight mb-6"
+            tw="font-bold tracking-tight"
             style={{
               fontFamily: "JetBrains Mono",
               color: zenColors.foreground,
-              lineHeight: 1.1,
+              lineHeight: 1.15,
+              fontSize: titleFontSize,
+              marginBottom: titleMarginBottom,
             }}
           >
             {title}
           </div>
 
           <div
-            tw="mb-8 h-[2px] w-32"
-            style={{ backgroundColor: zenColors.foreground, opacity: 0.15 }}
+            tw="w-32"
+            style={{
+              backgroundColor: zenColors.foreground,
+              opacity: 0.15,
+              height: "2px",
+              marginBottom: separatorMarginBottom,
+            }}
           />
 
           <div
-            tw="text-2xl leading-relaxed"
+            tw="leading-relaxed"
             style={{
               color: zenColors.muted,
-              lineHeight: 1.6,
+              lineHeight: 1.5,
               maxWidth: "500px",
+              fontSize: descFontSize,
             }}
           >
             {description}

--- a/src/contents/en/reinforcing-the-shield.mdx
+++ b/src/contents/en/reinforcing-the-shield.mdx
@@ -20,6 +20,7 @@ Art knows no borders, and the tools that protect it should not either. In PR #94
 -   [Coder-Blue](https://github.com/Coder-Blue) (me) (PR #97) drove the comprehensive UI implementation, translating and mapping every user-facing label, button, and description across all components to ensure a seamless, localized experience.
 
 ```typescript
+// src/lib/stores/use-i18n.svelte.ts
 let locale = $state<Locale>(detectLocale());
 
 export function t(key: string, params?: Record<string, string | number>): string {
@@ -64,6 +65,7 @@ In native runtimes, this memory safety violation triggers a `STATUS_ACCESS_VIOLA
 We resolved this by inlining image tensor creation in Glaze and Nightshade model runners, using boxed slices to explicitly manage data ownership and pinning buffers in memory to guarantee their validity throughout the entire lifecycle of the ONNX session:
 
 ```rust
+// src-tauri/src/onnx_integration/protection/algorithms.rs
 pub fn run_noise_model(session: &mut Session, input: &Array4<f32>) -> Result<f32, String> {
     let shape = input.shape();
     let data: Box<[f32]> = input
@@ -92,6 +94,7 @@ If the user then restarted the protection run, the application would spawn a sec
 We introduced thread-safe `AtomicBool` cancellation checks within all inner loops. Now, when a user clicks cancel, the background thread stops instantly, pending reset timers are cleared, and memory is immediately reclaimed:
 
 ```rust
+// src-tauri/src/onnx_integration/protection/spsa.rs
 for k in 0..iterations {
     if state.is_cancelled.load(Ordering::SeqCst) {
         return Err("Protection cancelled".to_string());

--- a/src/contents/en/reinforcing-the-shield.mdx
+++ b/src/contents/en/reinforcing-the-shield.mdx
@@ -19,6 +19,27 @@ Art knows no borders, and the tools that protect it should not either. In PR #94
 -   [kiensony](https://github.com/kiensony) (PR #94, #95) designed and built the lightweight, zero-dependency internationalization (i18n) core layer. Instead of adding a heavy external library, this custom layer integrates directly with Svelte 5 state runes, keeping memory overhead minimal. They also restyled the header language switcher to align visually with the theme toggle and system info controls.
 -   [Coder-Blue](https://github.com/Coder-Blue) (me) (PR #97) drove the comprehensive UI implementation, translating and mapping every user-facing label, button, and description across all components to ensure a seamless, localized experience.
 
+```typescript
+let locale = $state<Locale>(detectLocale());
+
+export function t(key: string, params?: Record<string, string | number>): string {
+  let message = resolveMessage(dictionaries[locale], key);
+  if (typeof message !== "string") {
+    message = resolveMessage(dictionaries.en, key);
+  }
+  if (typeof message !== "string") {
+    return key;
+  }
+  if (!params) {
+    return message;
+  }
+  return message.replace(/\{(\w+)\}/g, (match, name: string) => {
+    const value = params[name];
+    return value === undefined ? match : String(value);
+  });
+}
+```
+
 By avoiding bulky dependencies, we keep the webview bundle size compact, respecting user memory and disk limits while expanding global accessibility.
 
 ### Security Hardening: Securing the Webview-Backend Boundary (PR #93)
@@ -40,14 +61,56 @@ When compiling SPSA (Simultaneous Perturbation Stochastic Approximation) perturb
 
 In native runtimes, this memory safety violation triggers a `STATUS_ACCESS_VIOLATION` (segmentation fault). Because Tauri maps Rust panics and segmentation faults to a hard abort, the desktop window would instantly freeze or turn completely blank without showing any error message. For artists who may have spent 20 minutes processing high-resolution artwork, a sudden silent crash meant all progress was lost. 
 
-We resolved this by inlining image tensor creation in Glaze and Nightshade model runners, using boxed slices to explicitly manage data ownership and pinning buffers in memory to guarantee their validity throughout the entire lifecycle of the ONNX session.
+We resolved this by inlining image tensor creation in Glaze and Nightshade model runners, using boxed slices to explicitly manage data ownership and pinning buffers in memory to guarantee their validity throughout the entire lifecycle of the ONNX session:
+
+```rust
+pub fn run_noise_model(session: &mut Session, input: &Array4<f32>) -> Result<f32, String> {
+    let shape = input.shape();
+    let data: Box<[f32]> = input
+        .iter()
+        .copied()
+        .collect::<Vec<f32>>()
+        .into_boxed_slice();
+    let input_tensor = Tensor::from_array(([shape[0], shape[1], shape[2], shape[3]], data))
+        .map_err(|e| format!("Failed to create input tensor: {}", e))?;
+
+    let outputs = session
+        .run(ort::inputs![input_tensor])
+        .map_err(|e| format!("Failed to run noise model: {}", e))?;
+
+    outputs[0]
+        .try_extract_scalar::<f32>()
+        .map_err(|e| format!("Failed to extract noise model output: {}", e))
+}
+```
 
 #### 2. Background Cancellation Memory Leaks
 Another major issue was cancellation thread safety. When a user clicked "Cancel" on a running protection process in Svelte, the UI would instantly reset. However, the background Rust thread executing the heavy SPSA optimization loops would keep running silently in the background. 
 
 If the user then restarted the protection run, the application would spawn a second parallel SPSA thread. This led to a thread explosion and severe **VRAM/RAM leaks**, quickly causing system-wide freezes or Out-of-Memory (OOM) crashes. 
 
-We introduced thread-safe `AtomicBool` cancellation checks within all inner loops. Now, when a user clicks cancel, the background thread stops instantly, pending reset timers are cleared, and memory is immediately reclaimed.
+We introduced thread-safe `AtomicBool` cancellation checks within all inner loops. Now, when a user clicks cancel, the background thread stops instantly, pending reset timers are cleared, and memory is immediately reclaimed:
+
+```rust
+for k in 0..iterations {
+    if state.is_cancelled.load(Ordering::SeqCst) {
+        return Err("Protection cancelled".to_string());
+    }
+
+    let ck = ck_initial / ((k + 1) as f32).powf(0.101);
+    let ak = alpha / ((k + 1) as f32).powf(0.602);
+
+    let (grad_accum, valid_count) = (0..SPSA_DIRECTIONS_PER_ITER).try_fold(
+        (vec![0.0f32; num_elements], 0u32),
+        |(mut acc, count), _| {
+            if state.is_cancelled.load(Ordering::SeqCst) {
+                return Err("Protection cancelled".to_string());
+            }
+            Ok((acc, count + 1))
+        },
+    )?;
+}
+```
 
 ---
 

--- a/src/contents/vn/reinforcing-the-shield.mdx
+++ b/src/contents/vn/reinforcing-the-shield.mdx
@@ -19,6 +19,27 @@ Nghệ thuật không có ranh giới, và các công cụ bảo vệ nghệ thu
 -   [kiensony](https://github.com/kiensony) (PR #94, #95) đã thiết kế và xây dựng lớp cốt lõi bản địa hóa (i18n) nhẹ, không phụ thuộc thư viện ngoài. Thay vì thêm một thư viện cồng kềnh, lớp tùy chỉnh này tích hợp trực tiếp với các Svelte 5 state runes, giúp giảm thiểu tối đa dung lượng bộ nhớ. Họ cũng thiết kế lại trình chuyển đổi ngôn ngữ trên thanh tiêu đề để đồng bộ trực quan với các nút chuyển chủ đề và thông tin hệ thống.
 -   [Coder-Blue](https://github.com/Coder-Blue) (tôi) (PR #97) đã thúc đẩy việc triển khai giao diện hoàn chỉnh, dịch thuật và thiết lập mọi nhãn hiển thị, nút bấm cũng như phần mô tả trên tất cả các thành phần giao diện, mang lại trải nghiệm bản địa hóa liền mạch.
 
+```typescript
+let locale = $state<Locale>(detectLocale());
+
+export function t(key: string, params?: Record<string, string | number>): string {
+  let message = resolveMessage(dictionaries[locale], key);
+  if (typeof message !== "string") {
+    message = resolveMessage(dictionaries.en, key);
+  }
+  if (typeof message !== "string") {
+    return key;
+  }
+  if (!params) {
+    return message;
+  }
+  return message.replace(/\{(\w+)\}/g, (match, name: string) => {
+    const value = params[name];
+    return value === undefined ? match : String(value);
+  });
+}
+```
+
 Bằng cách tránh các thư viện phụ thuộc nặng nề, dung lượng mã nguồn của webview được giữ ở mức cực kỳ gọn nhẹ, tôn trọng giới hạn bộ nhớ và dung lượng ổ cứng của người dùng trong khi mở rộng khả năng tiếp cận toàn cầu.
 
 ### Thắt Chặt Bảo Mật: Bảo Vệ Ranh Giới Webview Và Backend (PR #93)
@@ -40,14 +61,56 @@ Khi biên dịch logic làm nhiễu đối kháng SPSA (Simultaneous Perturbatio
 
 Trong các môi trường chạy mã máy, vi phạm an toàn bộ nhớ này sẽ kích hoạt lỗi truy cập nghiêm trọng `STATUS_ACCESS_VIOLATION` (segmentation fault). Vì Tauri ánh xạ các lỗi sập luồng (panic/abort) của Rust thành việc dừng ứng dụng ngay lập tức, cửa sổ ứng dụng sẽ bị đóng băng hoặc chuyển sang màu trắng xóa mà không hiển thị bất kỳ thông báo lỗi nào. Đối với nghệ sĩ đã dành hàng chục phút để xử lý tác phẩm độ phân giải cao, lỗi sập đột ngột này đồng nghĩa với việc mất toàn bộ tiến trình.
 
-Chúng tôi đã khắc phục lỗi này bằng cách đóng gói việc tạo tensor hình ảnh ngay trong các trình chạy mô hình Glaze và Nightshade, sử dụng các lát cắt được đóng hộp (boxed slices) để quản lý rõ ràng quyền sở hữu dữ liệu và ghim các vùng đệm trong bộ nhớ nhằm đảm bảo tính hợp lệ của chúng trong suốt vòng đời của phiên ONNX.
+Chúng tôi đã khắc phục lỗi này bằng cách đóng gói việc tạo tensor hình ảnh ngay trong các trình chạy mô hình Glaze và Nightshade, sử dụng các lát cắt được đóng hộp (boxed slices) để quản lý rõ ràng quyền sở hữu dữ liệu và ghim các vùng đệm trong bộ nhớ nhằm đảm bảo tính hợp lệ của chúng trong suốt vòng đời của phiên ONNX:
+
+```rust
+pub fn run_noise_model(session: &mut Session, input: &Array4<f32>) -> Result<f32, String> {
+    let shape = input.shape();
+    let data: Box<[f32]> = input
+        .iter()
+        .copied()
+        .collect::<Vec<f32>>()
+        .into_boxed_slice();
+    let input_tensor = Tensor::from_array(([shape[0], shape[1], shape[2], shape[3]], data))
+        .map_err(|e| format!("Failed to create input tensor: {}", e))?;
+
+    let outputs = session
+        .run(ort::inputs![input_tensor])
+        .map_err(|e| format!("Failed to run noise model: {}", e))?;
+
+    outputs[0]
+        .try_extract_scalar::<f32>()
+        .map_err(|e| format!("Failed to extract noise model output: {}", e))
+}
+```
 
 #### 2. Rò Rỉ Bộ Nhớ Khi Hủy Tác Vụ Trong Nền
 Một vấn đề lớn khác là an toàn luồng khi hủy tác vụ. Khi người dùng nhấp vào nút "Hủy" tiến trình bảo vệ trong giao diện Svelte, giao diện người dùng sẽ lập tức thiết lập lại. Tuy nhiên, luồng Rust chạy ngầm thực hiện các vòng lặp tối ưu hóa SPSA nặng nề vẫn tiếp tục chạy ẩn.
 
 Nếu người dùng bắt đầu lại tiến trình bảo vệ, ứng dụng sẽ sinh ra luồng SPSA thứ hai song song. Điều này dẫn đến sự bùng nổ số lượng luồng và **rò rỉ VRAM/RAM nghiêm trọng**, nhanh chóng gây đóng băng toàn bộ hệ thống hoặc sập ứng dụng do tràn bộ nhớ (Out-of-Memory).
 
-Chúng tôi đã chèn các kiểm tra hủy tác vụ an toàn luồng bằng `AtomicBool` bên trong tất cả các vòng lặp nội bộ. Hiện tại, khi người dùng nhấp hủy, luồng ngầm sẽ dừng lại ngay lập tức, các bộ hẹn giờ đặt lại được dọn sạch và bộ nhớ được giải phóng ngay.
+Chúng tôi đã chèn các kiểm tra hủy tác vụ an toàn luồng bằng `AtomicBool` bên trong tất cả các vòng lặp nội bộ. Hiện tại, khi người dùng nhấp hủy, luồng ngầm sẽ dừng lại ngay lập tức, các bộ hẹn giờ đặt lại được dọn sạch và bộ nhớ được giải phóng ngay:
+
+```rust
+for k in 0..iterations {
+    if state.is_cancelled.load(Ordering::SeqCst) {
+        return Err("Protection cancelled".to_string());
+    }
+
+    let ck = ck_initial / ((k + 1) as f32).powf(0.101);
+    let ak = alpha / ((k + 1) as f32).powf(0.602);
+
+    let (grad_accum, valid_count) = (0..SPSA_DIRECTIONS_PER_ITER).try_fold(
+        (vec![0.0f32; num_elements], 0u32),
+        |(mut acc, count), _| {
+            if state.is_cancelled.load(Ordering::SeqCst) {
+                return Err("Protection cancelled".to_string());
+            }
+            Ok((acc, count + 1))
+        },
+    )?;
+}
+```
 
 ---
 

--- a/src/contents/vn/reinforcing-the-shield.mdx
+++ b/src/contents/vn/reinforcing-the-shield.mdx
@@ -20,6 +20,7 @@ Nghệ thuật không có ranh giới, và các công cụ bảo vệ nghệ thu
 -   [Coder-Blue](https://github.com/Coder-Blue) (tôi) (PR #97) đã thúc đẩy việc triển khai giao diện hoàn chỉnh, dịch thuật và thiết lập mọi nhãn hiển thị, nút bấm cũng như phần mô tả trên tất cả các thành phần giao diện, mang lại trải nghiệm bản địa hóa liền mạch.
 
 ```typescript
+// src/lib/stores/use-i18n.svelte.ts
 let locale = $state<Locale>(detectLocale());
 
 export function t(key: string, params?: Record<string, string | number>): string {
@@ -64,6 +65,7 @@ Trong các môi trường chạy mã máy, vi phạm an toàn bộ nhớ này s�
 Chúng tôi đã khắc phục lỗi này bằng cách đóng gói việc tạo tensor hình ảnh ngay trong các trình chạy mô hình Glaze và Nightshade, sử dụng các lát cắt được đóng hộp (boxed slices) để quản lý rõ ràng quyền sở hữu dữ liệu và ghim các vùng đệm trong bộ nhớ nhằm đảm bảo tính hợp lệ của chúng trong suốt vòng đời của phiên ONNX:
 
 ```rust
+// src-tauri/src/onnx_integration/protection/algorithms.rs
 pub fn run_noise_model(session: &mut Session, input: &Array4<f32>) -> Result<f32, String> {
     let shape = input.shape();
     let data: Box<[f32]> = input
@@ -92,6 +94,7 @@ Nếu người dùng bắt đầu lại tiến trình bảo vệ, ứng dụng s
 Chúng tôi đã chèn các kiểm tra hủy tác vụ an toàn luồng bằng `AtomicBool` bên trong tất cả các vòng lặp nội bộ. Hiện tại, khi người dùng nhấp hủy, luồng ngầm sẽ dừng lại ngay lập tức, các bộ hẹn giờ đặt lại được dọn sạch và bộ nhớ được giải phóng ngay:
 
 ```rust
+// src-tauri/src/onnx_integration/protection/spsa.rs
 for k in 0..iterations {
     if state.is_cancelled.load(Ordering::SeqCst) {
         return Err("Protection cancelled".to_string());


### PR DESCRIPTION
Prevent text overflow in the DefaultOG template by scaling font sizes and margins dynamically. Insert real Svelte 5 and Rust code snippets from hope-re repository for zero-dependency i18n, boxed tensor memory pinning, and thread cancellation in the reinforcing-the-shield blog post.
